### PR TITLE
Change ystemVms TemplateUrlBase and small fix on jenkins badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Autonomiccs Platform](tools/project-logo/autonomiccs.png)](http://autonomiccs.com.br)
 
-###Project stats: [![Build Status](http://jenkins.autonomiccs.com.br/buildStatus/icon?job=Autonomiccs-platform)](http://jenkins.autonomiccs.com.br/job/Autonomiccs-platform/) <a href="https://scan.coverity.com/projects/autonomiccs-platform"><img alt="Coverity Scan Build Status" src="https://scan.coverity.com/projects/8610/badge.svg"/></a>
+###Project stats: [![Build Status](http://jenkinsbadge.autonomiccs.com.br/buildStatus/icon?job=Autonomiccs-platform)](http://jenkins.autonomiccs.com.br/job/Autonomiccs-platform/) <a href="https://scan.coverity.com/projects/autonomiccs-platform"><img alt="Coverity Scan Build Status" src="https://scan.coverity.com/projects/8610/badge.svg"/></a>
 
 In a nut shell, Autonomiccs is a distributed virtual machine scheduling (A.K.A distributed resource scheduling) for Apache CloudStack.
 

--- a/autonomic-plugin-common/src/main/resources/META-INF/cloudstack/autonomiccsPlugins/spring-autonomiccsPlugins-context.xml
+++ b/autonomic-plugin-common/src/main/resources/META-INF/cloudstack/autonomiccsPlugins/spring-autonomiccsPlugins-context.xml
@@ -95,7 +95,7 @@
     <bean class="br.com.autonomiccs.autonomic.plugin.common.daos.AutonomiccsSystemVmJdbcDao" parent="absctractDao"/>
     
 	<bean id="autonomiccsSystemVmsTemplateUrlBase" class="java.lang.String">
-		<constructor-arg value="http://autonomiccs.com.br/systemVmsTemplate" />
+		<constructor-arg value="http://templates.autonomiccs.com.br/systemVmsTemplate" />
 	</bean>
 	<bean id="systemVmTemplateVersion" class="java.lang.String">
 		<constructor-arg value="1.0" />


### PR DESCRIPTION
URL (autonomiccsSystemVmsTemplateUrlBase) changed from
“autonomiccs.com.br” to “templates.autonomiccs.com.br”.

Jenkins badge URL changed to jenkinsbadge.autonomiccs.com.br in order to
allow HTTP access to the badge.
