### PR TITLE
Change the default management algorithm that is set during installation

### DIFF
--- a/autonomic-plugin-common/src/main/java/br/com/autonomiccs/autonomic/plugin/common/daos/configurations/ConfigureDatabaseDao.java
+++ b/autonomic-plugin-common/src/main/java/br/com/autonomiccs/autonomic/plugin/common/daos/configurations/ConfigureDatabaseDao.java
@@ -25,7 +25,6 @@ package br.com.autonomiccs.autonomic.plugin.common.daos.configurations;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
 
 import br.com.autonomiccs.autonomic.administration.algorithms.impl.ClusterManagementDummyAlgorithm;
-import br.com.autonomiccs.autonomic.administration.algorithms.impl.VmsDispersionAlgorithmForHomogeneousEnvironment;
 import br.com.autonomiccs.autonomic.plugin.common.services.AutonomicClusterManagementHeuristicService;
 
 /**
@@ -53,7 +52,7 @@ public class ConfigureDatabaseDao extends JdbcDaoSupport {
     private String sqlInsertIntoConfigurationClusterAlgorithms = String.format(
             "INSERT INTO configuration (category,instance,component,name,value,description,default_value,updated,scope,is_dynamic) VALUES ('Advanced','DEFAULT','autonomicClusterManager','%s','%s','Full qualified heuristic class name to be used to guide the agent during the cluster management process.','%s',null,null,0);",
             AutonomicClusterManagementHeuristicService.CLUSTER_ADMINISTRATION_ALGORITHMS_IN_CONFIGURATION_KEY,
-            VmsDispersionAlgorithmForHomogeneousEnvironment.class.getCanonicalName(), ClusterManagementDummyAlgorithm.class.getCanonicalName());
+            ClusterManagementDummyAlgorithm.class.getCanonicalName(), ClusterManagementDummyAlgorithm.class.getCanonicalName());
 
     private String sqlHasAutonomiccsSystemVmTable = "SHOW TABLES LIKE 'AutonomiccsSystemVm';";
     private String sqlCreateAutonomiccsSystemVmTable = "CREATE TABLE AutonomiccsSystemVm(id BIGINT(20) UNSIGNED, public_ip_address VARCHAR(40), management_ip_address VARCHAR(40));";

--- a/autonomic-plugin-common/src/test/java/br/com/autonomiccs/autonomic/plugin/common/daos/configurations/ConfigureDatabaseDaoTest.java
+++ b/autonomic-plugin-common/src/test/java/br/com/autonomiccs/autonomic/plugin/common/daos/configurations/ConfigureDatabaseDaoTest.java
@@ -38,7 +38,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import br.com.autonomiccs.autonomic.administration.algorithms.impl.ClusterManagementDummyAlgorithm;
-import br.com.autonomiccs.autonomic.administration.algorithms.impl.VmsDispersionAlgorithmForHomogeneousEnvironment;
 import br.com.autonomiccs.autonomic.plugin.common.services.AutonomicClusterManagementHeuristicService;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -60,7 +59,7 @@ public class ConfigureDatabaseDaoTest {
     private String sqlInsertIntoConfigurationClusterAlgorithms = String.format(
             "INSERT INTO configuration (category,instance,component,name,value,description,default_value,updated,scope,is_dynamic) VALUES ('Advanced','DEFAULT','autonomicClusterManager','%s','%s','Full qualified heuristic class name to be used to guide the agent during the cluster management process.','%s',null,null,0);",
             AutonomicClusterManagementHeuristicService.CLUSTER_ADMINISTRATION_ALGORITHMS_IN_CONFIGURATION_KEY,
-            VmsDispersionAlgorithmForHomogeneousEnvironment.class.getCanonicalName(), ClusterManagementDummyAlgorithm.class.getCanonicalName());
+            ClusterManagementDummyAlgorithm.class.getCanonicalName(), ClusterManagementDummyAlgorithm.class.getCanonicalName());
     private String sqlHasAutonomiccsSystemVmTable = "SHOW TABLES LIKE 'AutonomiccsSystemVm';";
     private String sqlCreateAutonomiccsSystemVmTable = "CREATE TABLE AutonomiccsSystemVm(id BIGINT(20) UNSIGNED, public_ip_address VARCHAR(40), management_ip_address VARCHAR(40));";
 

--- a/tools/licenses/licenses-header-template
+++ b/tools/licenses/licenses-header-template
@@ -27,7 +27,7 @@
  Licensed to the Autonomiccs, Inc. under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
- regarding copyright ownership. The The Autonomiccs, Inc. licenses this file
+ regarding copyright ownership. The Autonomiccs, Inc. licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at


### PR DESCRIPTION
Currently, the default algorithm that is set during the installation
process is the
“br.com.autonomiccs.autonomic.administration.algorithms.impl.VmsDispersionAlgorithmForHomogeneousEnvironment”
heuristic. However, it would be more interesting to set the
“br.com.autonomiccs.autonomic.administration.algorithms.impl.ClusterManagementDummyAlgorithm”
as the one to be used right after the installation process. 
That way, we avoid unexpected behaviors in freshly installed
environments.

This fixes #26
