### PR TITLE
Remove Jade agent from move jars script

### DIFF
--- a/tools/scripts/build/templateInstallationPackage/autonomiccsJars/moveJars.sh
+++ b/tools/scripts/build/templateInstallationPackage/autonomiccsJars/moveJars.sh
@@ -30,17 +30,12 @@ cp autonomiccsJars/dependencies/*.jar /usr/share/cloudstack-management/webapps/c
 # Creation of a folder to hold the jar files that needs to get transfered to VMs.
 baseAutonomiccsJarFolder="/var/lib/autonomiccs/jars/";
 
-jadeAgentsFolder="${baseAutonomiccsJarFolder}jade/";
 wakeOnLanFolder="${baseAutonomiccsJarFolder}wakeonlan/";
 
 wakeOnLanFileName="wakeonlan-service";
-jadeAgentsFileName="jade-plataform-agents";
 
-jadeAgentsRegex="autonomiccsJars/$jadeAgentsFileName-*.jar";
 wakeOnLanRegex="autonomiccsJars/$wakeOnLanFileName-*.jar"; 
 
-mkdir -p $jadeAgentsFolder;
 mkdir -p $wakeOnLanFolder;
 
 cp $wakeOnLanRegex "$wakeOnLanFolder$wakeOnLanNewFileName.jar";
-cp $jadeAgentsRegex "$jadeAgentsFolder$jadeAgentsNewFileName.jar";


### PR DESCRIPTION
Remove Jade agent from `moveJars.sh` script as jar is not included in `installationFolder/autonomiccsJars`